### PR TITLE
Refactor engine for improved experience

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,6 @@
+exclude_paths:
+  - spec/dummy/
+
+detectors:
+  TooManyStatements:
+    max_statements: 10

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,9 @@ require:
 AllCops:
   TargetRubyVersion: 3.1
   NewCops: enable
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+RSpec/ExampleLength:
+  Max: 10
+RSpec/NestedGroups:
+  Max: 4

--- a/app/controllers/concerns/event_logger_rails/loggable.rb
+++ b/app/controllers/concerns/event_logger_rails/loggable.rb
@@ -9,10 +9,9 @@ module EventLoggerRails
     def log_event(level, event, **data)
       data_to_log = data_from_request.merge(data)
       EventLoggerRails.log(level, event, **data_to_log)
-    rescue EventLoggerRails::Exceptions::UnregisteredEvent => e
-      log_event :error, 'event_logger_rails.event.unregistered', message: e.message
-    rescue EventLoggerRails::Exceptions::InvalidLoggerLevel => e
-      log_event :error, 'event_logger_rails.logger_level.invalid', message: e.message
+    rescue EventLoggerRails::Exceptions::UnregisteredEvent,
+           EventLoggerRails::Exceptions::InvalidLoggerLevel => error
+      log_event :error, error.event, message: error.message
     end
 
     def data_from_request

--- a/lib/event_logger_rails.rb
+++ b/lib/event_logger_rails.rb
@@ -5,18 +5,22 @@ require 'active_support/dependencies'
 require 'event_logger_rails/version'
 require 'event_logger_rails/engine'
 require 'event_logger_rails/event_logger'
+require 'event_logger_rails/event'
+require 'event_logger_rails/level'
 require 'event_logger_rails/exceptions/invalid_logger_level'
 require 'event_logger_rails/exceptions/unregistered_event'
 
 ##
-# Namespace for UtilityClasses gem
+# Namespace for EventLoggerRails gem
 module EventLoggerRails
   autoload :EventLogger, 'event_logger_rails/event_logger'
+  autoload :Event, 'event_logger_rails/event'
+  autoload :Level, 'event_logger_rails/level'
   autoload :InvalidLoggerLevel, 'event_logger_rails/exceptions/invalid_logger_level'
   autoload :UnregisteredEvent, 'event_logger_rails/exceptions/unregistered_event'
 
-  self.mattr_accessor :registered_events
-  self.mattr_accessor :logger_levels
+  mattr_accessor :registered_events
+  mattr_accessor :logger_levels
 
   def self.setup
     yield self

--- a/lib/event_logger_rails/engine.rb
+++ b/lib/event_logger_rails/engine.rb
@@ -6,8 +6,8 @@ module EventLoggerRails
   class Engine < ::Rails::Engine
     isolate_namespace EventLoggerRails
 
-    config.generators do |g|
-      g.test_framework :rspec
+    config.generators do |generator|
+      generator.test_framework :rspec
     end
   end
 end

--- a/lib/event_logger_rails/event.rb
+++ b/lib/event_logger_rails/event.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module EventLoggerRails
+  ##
+  # Models an event for logging.
+  class Event
+    DEFAULT_EVENTS = [
+      'event_logger_rails.logger_level.invalid',
+      'event_logger_rails.event.unregistered',
+      'event_logger_rails.event.testing'
+    ].freeze
+    private_constant :DEFAULT_EVENTS
+
+    def initialize(identifier)
+      @identifier = identifier
+    end
+
+    def valid?
+      event_registered? || default_event?
+    end
+
+    def to_s
+      identifier.to_s
+    end
+
+    def ==(other)
+      identifier.to_s == other.to_s
+    end
+
+    private
+
+    attr_reader :identifier
+
+    def event_registered?
+      parsed_event = identifier.split('.').map(&:to_sym)
+      EventLoggerRails.registered_events.dig(*parsed_event)
+    end
+
+    def default_event?
+      DEFAULT_EVENTS.include?(identifier)
+    end
+  end
+end

--- a/lib/event_logger_rails/exceptions/invalid_logger_level.rb
+++ b/lib/event_logger_rails/exceptions/invalid_logger_level.rb
@@ -5,11 +5,22 @@ module EventLoggerRails
     ##
     # Indicates invalid log level provided.
     class InvalidLoggerLevel < StandardError
-      attr_reader :logger_level
+      attr_reader :event
 
       def initialize(logger_level:)
-        super("Invalid logger level provided: '#{logger_level}'. Valid levels: debug, info, warn, error, fatal.")
+        super
+        @event = EventLoggerRails::Event.new('event_logger_rails.logger_level.invalid')
+        @logger_level = logger_level
       end
+
+      def message
+        "Invalid logger level provided: '#{logger_level.to_sym}'. " \
+          "Valid levels: #{EventLoggerRails.logger_levels.map(&:inspect).join(', ')}."
+      end
+
+      private
+
+      attr_reader :logger_level
     end
   end
 end

--- a/lib/event_logger_rails/exceptions/unregistered_event.rb
+++ b/lib/event_logger_rails/exceptions/unregistered_event.rb
@@ -5,11 +5,21 @@ module EventLoggerRails
     ##
     # Indicates event provided not registered.
     class UnregisteredEvent < StandardError
-      attr_reader :unregistered_event
+      attr_reader :event
 
       def initialize(unregistered_event:)
-        super("Event provided not registered: #{unregistered_event}")
+        super()
+        @event = EventLoggerRails::Event.new('event_logger_rails.event.unregistered')
+        @unregistered_event = unregistered_event
       end
+
+      def message
+        "Event provided not registered: #{unregistered_event}"
+      end
+
+      private
+
+      attr_reader :unregistered_event
     end
   end
 end

--- a/lib/event_logger_rails/level.rb
+++ b/lib/event_logger_rails/level.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module EventLoggerRails
+  ##
+  # Models a logger level
+  class Level
+    def initialize(level)
+      @level = level
+    end
+
+    def valid?
+      EventLoggerRails.logger_levels.include?(level)
+    end
+
+    def to_s
+      level.to_s
+    end
+
+    def to_sym
+      level.to_sym
+    end
+
+    private
+
+    attr_reader :level
+  end
+end

--- a/spec/lib/event_logger_rails/event_logger_spec.rb
+++ b/spec/lib/event_logger_rails/event_logger_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLoggerRails::EventLogger do
+  subject(:event_logger) { described_class.new }
+
+  describe '#log' do
+    subject(:method_call) { event_logger.log(level, event, **data) }
+
+    let(:level) { instance_double(EventLoggerRails::Level, to_s: 'info', to_sym: :info, valid?: true) }
+    let(:event) { instance_double(EventLoggerRails::Event, to_s: 'foo.bar', valid?: true) }
+    let(:data) { { foo: 'bar' } }
+
+    let(:output_spy) { instance_spy(File) }
+
+    before do
+      allow(EventLoggerRails::Level).to receive(:new).and_return(level)
+      allow(EventLoggerRails::Event).to receive(:new).and_return(event)
+      allow(File).to receive(:open).and_return(output_spy)
+    end
+
+    it 'logs the data with the level, datetime, and event tags' do
+      method_call
+      date_regexp = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/
+      expect(output_spy)
+        .to have_received(:write)
+        .with(/\[(#{level.to_s.upcase}) \| #{date_regexp} \| (#{event})\] (#{data.as_json})/)
+    end
+
+    context 'when an identifier is provided instead of an EventLoggerRails::Event object' do
+      let(:event) { 'event_logger_rails.event.testing' }
+
+      before do
+        allow(EventLoggerRails::Event).to receive(:new).and_call_original
+      end
+
+      it 'logs the data with the level, datetime, and event tags' do
+        method_call
+        date_regexp = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/
+        expect(output_spy)
+          .to have_received(:write)
+          .with(/\[(#{level.to_s.upcase}) \| #{date_regexp} \| (#{event})\] (#{data.as_json})/)
+      end
+    end
+
+    context 'when a level symbol is provided instead of an EventLoggerRails::Level object' do
+      let(:level) { :info }
+
+      before do
+        allow(EventLoggerRails::Level).to receive(:new).and_call_original
+      end
+
+      it 'logs the data with the level, datetime, and event tags' do
+        method_call
+        date_regexp = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/
+        expect(output_spy)
+          .to have_received(:write)
+          .with(/\[(#{level.to_s.upcase}) \| #{date_regexp} \| (#{event})\] (#{data.as_json})/)
+      end
+    end
+
+    context 'when the level is not valid' do
+      let(:level) { instance_double(EventLoggerRails::Level, to_s: 'info', to_sym: :info, valid?: false) }
+
+      it 'does not output a log entry' do
+        begin
+          method_call
+        rescue EventLoggerRails::Exceptions::InvalidLoggerLevel
+          nil
+        end
+        expect(output_spy).not_to have_received(:write)
+      end
+
+      it 'raises an error' do
+        expect { method_call }.to raise_error(EventLoggerRails::Exceptions::InvalidLoggerLevel)
+      end
+
+      it 'initializes the error with the logger level' do
+        allow(EventLoggerRails::Exceptions::InvalidLoggerLevel).to receive(:new).and_call_original
+
+        begin
+          method_call
+        rescue EventLoggerRails::Exceptions::InvalidLoggerLevel
+          nil
+        end
+
+        expect(EventLoggerRails::Exceptions::InvalidLoggerLevel).to have_received(:new).with(logger_level: level)
+      end
+    end
+
+    context 'when the event is not valid' do
+      let(:event) { instance_double(EventLoggerRails::Event, to_s: 'foo.bar', valid?: false) }
+
+      it 'does not output a log entry' do
+        begin
+          method_call
+        rescue EventLoggerRails::Exceptions::UnregisteredEvent
+          nil
+        end
+        expect(output_spy).not_to have_received(:write)
+      end
+
+      it 'raises an error' do
+        expect { method_call }.to raise_error(EventLoggerRails::Exceptions::UnregisteredEvent)
+      end
+
+      it 'initializes the error with the event' do
+        allow(EventLoggerRails::Exceptions::UnregisteredEvent).to receive(:new).and_call_original
+
+        begin
+          method_call
+        rescue EventLoggerRails::Exceptions::UnregisteredEvent
+          nil
+        end
+
+        expect(EventLoggerRails::Exceptions::UnregisteredEvent)
+          .to have_received(:new)
+          .with(unregistered_event: event)
+      end
+    end
+  end
+end

--- a/spec/lib/event_logger_rails/event_spec.rb
+++ b/spec/lib/event_logger_rails/event_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLoggerRails::Event do
+  subject(:event) { described_class.new(identifier) }
+
+  describe '#valid?' do
+    subject(:method_call) { event.valid? }
+
+    let(:valid_registered_event) { 'valid.event' }
+
+    before do
+      EventLoggerRails.setup do |config|
+        config.registered_events = { valid: { event: 'This is a valid event.' } }
+      end
+    end
+
+    context 'when provided identifier is not a registered event' do
+      let(:identifier) { 'foobar' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when provided identifier is a registered event' do
+      let(:identifier) { valid_registered_event }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the event_logger_rails.logger_level.invalid event identifier is provided' do
+      let(:identifier) { 'event_logger_rails.logger_level.invalid' }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the event_logger_rails.event.unregistered event identifier is provided' do
+      let(:identifier) { 'event_logger_rails.event.unregistered' }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the event_logger_rails.event.testing event identifier is provided' do
+      let(:identifier) { 'event_logger_rails.event.testing' }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#to_s' do
+    subject(:method_call) { event.to_s }
+
+    let(:identifier) { 'foo.bar' }
+
+    it { is_expected.to eq(identifier) }
+  end
+
+  describe '#==' do
+    subject(:method_call) { event == other_event }
+
+    let(:identifier) { 'foobar' }
+
+    context 'when the other object is a string' do
+      context 'with a value matching the event identifier' do
+        let(:other_event) { event }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with a value not matching the event identifier' do
+        let(:other_event) { 'foobarbaz' }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context 'when the other object is another object that can be converted to a string' do
+      context 'with a value matching the event identifier' do
+        let(:other_event) { described_class.new(event) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with a value not matching the event identifier' do
+        let(:other_event) { described_class.new('foobarbaz') }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/lib/event_logger_rails/exceptions/invalid_logger_level_spec.rb
+++ b/spec/lib/event_logger_rails/exceptions/invalid_logger_level_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLoggerRails::Exceptions::InvalidLoggerLevel do
+  subject(:exception) { described_class.new(logger_level:) }
+
+  let(:logger_level) { instance_double(EventLoggerRails::Level, to_s: 'foobar', to_sym: ':foobar') }
+  let(:levels) { %i[foo bar baz] }
+
+  before do
+    EventLoggerRails.setup do |config|
+      config.logger_levels = levels
+    end
+  end
+
+  it 'returns the event reserved for the exception' do
+    expect(exception.event).to eq('event_logger_rails.logger_level.invalid')
+  end
+
+  it 'returns a message with the invalid logger level as well as the valid logger levels' do
+    expect(exception.message).to eq(
+      "Invalid logger level provided: '#{logger_level.to_sym}'. Valid levels: #{levels.map(&:inspect).join(', ')}."
+    )
+  end
+end

--- a/spec/lib/event_logger_rails/exceptions/unregistered_event_spec.rb
+++ b/spec/lib/event_logger_rails/exceptions/unregistered_event_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLoggerRails::Exceptions::UnregisteredEvent do
+  subject(:exception) { described_class.new(unregistered_event:) }
+
+  let(:unregistered_event) { instance_double(EventLoggerRails::Event, to_s: 'foobar') }
+
+  before do
+    EventLoggerRails.setup do |config|
+      config.registered_events = 'foo.bar.baz'
+    end
+  end
+
+  it 'returns the event reserved for the exception' do
+    expect(exception.event).to eq('event_logger_rails.event.unregistered')
+  end
+
+  it 'returns a message with the unregistered event' do
+    expect(exception.message).to eq("Event provided not registered: #{unregistered_event}")
+  end
+end

--- a/spec/lib/event_logger_rails/level_spec.rb
+++ b/spec/lib/event_logger_rails/level_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLoggerRails::Level do
+  subject(:level) { described_class.new(logger_level) }
+
+  describe '#valid?' do
+    subject(:method_call) { level.valid? }
+
+    let(:valid_logger_level) { :info }
+
+    before do
+      EventLoggerRails.setup do |config|
+        config.logger_levels = [valid_logger_level]
+      end
+    end
+
+    context 'when provided level is not a configured logger level' do
+      let(:logger_level) { :foobar }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when provided level is a configured logger level' do
+      let(:logger_level) { valid_logger_level }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#to_s' do
+    subject(:method_call) { level.to_s }
+
+    let(:logger_level) { :info }
+
+    it { is_expected.to eq(logger_level.to_s) }
+  end
+
+  describe '#to_sym' do
+    subject(:method_call) { level.to_sym }
+
+    let(:logger_level) { :info }
+
+    it { is_expected.to eq(logger_level) }
+  end
+end

--- a/spec/lib/event_logger_rails_spec.rb
+++ b/spec/lib/event_logger_rails_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventLoggerRails do
+  subject(:engine) { described_class }
+
+  describe '.setup' do
+    subject(:engine_setup) do
+      engine.setup do |config|
+        config.registered_events = events
+        config.logger_levels = levels
+      end
+    end
+
+    let(:events) { 'foo' }
+    let(:levels) { 'bar' }
+
+    it 'configures the registered events' do
+      engine_setup
+      expect(described_class.registered_events).to eq(events)
+    end
+
+    it 'configures the logger levels' do
+      engine_setup
+      expect(described_class.logger_levels).to eq(levels)
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors the core EventLoggerRails functionality without affecting the API for using it.

It...

- Breaks up the logger class to better adhere to separation of concerns.
- Adds specs for each class.
- Removes config file hot reloading, preferring to read configuration from what is set in the initializer.
- Vastly improves the robustness of the engine.
