### PR TITLE
Refactor to load configuration in initializer

### DIFF
--- a/lib/event_logger_rails.rb
+++ b/lib/event_logger_rails.rb
@@ -15,6 +15,13 @@ module EventLoggerRails
   autoload :InvalidLoggerLevel, 'event_logger_rails/exceptions/invalid_logger_level'
   autoload :UnregisteredEvent, 'event_logger_rails/exceptions/unregistered_event'
 
+  self.mattr_accessor :registered_events
+  self.mattr_accessor :logger_levels
+
+  def self.setup
+    yield self
+  end
+
   def self.logger
     @logger ||= EventLogger.new
   end

--- a/lib/generators/event_logger_rails/install_generator.rb
+++ b/lib/generators/event_logger_rails/install_generator.rb
@@ -1,15 +1,25 @@
 # frozen_string_literal: true
 
+require 'rails/generators'
+
 module EventLoggerRails
   module Generators
     ##
-    # Creates basic config file for EventLoggerRails
+    # Creates basic config file and initializer for EventLoggerRails
     class InstallGenerator < Rails::Generators::Base
-      desc 'Create basic config file for EventLoggerRails'
+      desc 'Create basic config file and initializer for EventLoggerRails'
       source_root File.expand_path('templates', __dir__)
 
       def copy_config_file
+        return if File.exist?(File.join(destination_root, 'config/event_logger_rails.yml'))
+
         copy_file 'event_logger_rails.yml', 'config/event_logger_rails.yml'
+      end
+
+      def copy_initializer
+        return if File.exist?(File.join(destination_root, 'config/initializers/event_logger_rails.rb'))
+
+        copy_file 'event_logger_rails.rb', 'config/initializers/event_logger_rails.rb'
       end
     end
   end

--- a/lib/generators/event_logger_rails/templates/event_logger_rails.rb
+++ b/lib/generators/event_logger_rails/templates/event_logger_rails.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+config_file = Rails.root.join('config/event_logger_rails.yml')
+config_from_file = YAML.safe_load(File.read(config_file)).deep_symbolize_keys
+
+EventLoggerRails.setup do |config|
+  config.registered_events = config_from_file[:registered_events]
+  config.logger_levels = config_from_file[:logger_levels].map(&:to_sym)
+end


### PR DESCRIPTION
This PR refactors the configuration to load through an initializer and updates the install generator to safely provide a default config file and initializer.
