### PR TITLE
Fix unreleased link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/d3d1rty/event_logger_rails/compare/0.1.0...HEAD
+[Unreleased]: https://github.com/d3d1rty/event_logger_rails/compare/0.2.1...HEAD
 [0.2.1]: https://github.com/d3d1rty/event_logger_rails/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/d3d1rty/event_logger_rails/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/d3d1rty/event_logger_rails/releases/tag/0.1.0


### PR DESCRIPTION
This PR fixes the unreleased link in the CHANGELOG to point to the correct tag.
