### PR TITLE
Clean up event logger

### DIFF
--- a/lib/event_logger_rails/event_logger.rb
+++ b/lib/event_logger_rails/event_logger.rb
@@ -10,32 +10,31 @@ module EventLoggerRails
   class EventLogger
     def initialize(output_device: $stdout)
       @logger = Logger.new(output_device)
+      @logger.formatter = proc do |severity, datetime, _progname, message|
+        JSON.dump(severity:, timestamp: datetime.to_s, message:)
+      end
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def log(event, level = :warn, **data)
       event = event.is_a?(EventLoggerRails::Event) ? event : EventLoggerRails::Event.new(event)
       raise EventLoggerRails::Exceptions::UnregisteredEvent.new(unregistered_event: event) unless event.valid?
 
-      logger.formatter = proc do |severity, datetime, _progname, message|
-        JSON.dump(severity:, timestamp: datetime.to_s, message:)
-      end
-
-      begin
-        logger.send(level) do
-          { event_identifier: event.identifier, event_description: event.description }.merge(data)
-        end
-      rescue NoMethodError
-        raise EventLoggerRails::Exceptions::InvalidLoggerLevel.new(logger_level: level)
-      end
+      log_message(event, level, **data)
     rescue EventLoggerRails::Exceptions::UnregisteredEvent,
            EventLoggerRails::Exceptions::InvalidLoggerLevel => error
       log(error.event, :error, message: error.message)
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 
     attr_reader :logger
+
+    def log_message(event, level, **data)
+      logger.send(level) do
+        { event_identifier: event.identifier, event_description: event.description }.merge(data)
+      end
+    rescue NoMethodError
+      raise EventLoggerRails::Exceptions::InvalidLoggerLevel.new(logger_level: level)
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR cleans up the event logger by setting the format options in the initializer (since this won't change between calls to `log`) and implementing the message passing in its own method (`log_message`) which is called by the `log` method. This refactor eliminates the need to disable rubocop formatting.

## Testing

Ensure test suite passes.
