### PR TITLE
Filter sensitive fields

### DIFF
--- a/app/controllers/concerns/event_logger_rails/loggable_controller.rb
+++ b/app/controllers/concerns/event_logger_rails/loggable_controller.rb
@@ -14,7 +14,7 @@ module EventLoggerRails
         method: request.method,
         path: request.path,
         remote_ip: request.remote_ip,
-        parameters: request.query_parameters.to_json
+        parameters: request.parameters
       }
     end
 

--- a/lib/event_logger_rails.rb
+++ b/lib/event_logger_rails.rb
@@ -21,6 +21,7 @@ module EventLoggerRails
   mattr_accessor :logdev
   mattr_accessor :logger_class
   mattr_accessor :registered_events
+  mattr_accessor :sensitive_fields
 
   def self.setup
     yield self

--- a/lib/event_logger_rails/engine.rb
+++ b/lib/event_logger_rails/engine.rb
@@ -19,6 +19,7 @@ module EventLoggerRails
         engine.registered_events = Rails.application.config_for(:event_logger_rails)
         engine.logdev = app.config.event_logger_rails.logdev
         engine.logger_class = app.config.event_logger_rails.logger_class
+        engine.sensitive_fields = app.config.filter_parameters
       end
     end
   end

--- a/lib/event_logger_rails/event_logger.rb
+++ b/lib/event_logger_rails/event_logger.rb
@@ -31,7 +31,8 @@ module EventLoggerRails
 
     def log_message(event, level, data)
       logger.send(level) do
-        { event_identifier: event.identifier, event_description: event.description }.merge(data)
+        filtered_data = ActiveSupport::ParameterFilter.new(EventLoggerRails.sensitive_fields).filter(data)
+        { event_identifier: event.identifier, event_description: event.description }.merge(filtered_data)
       end
     rescue NoMethodError
       raise EventLoggerRails::Exceptions::InvalidLoggerLevel.new(logger_level: level)

--- a/spec/app/controllers/concerns/event_logger_rails/loggable_controller_spec.rb
+++ b/spec/app/controllers/concerns/event_logger_rails/loggable_controller_spec.rb
@@ -24,13 +24,13 @@ class DummyController < ActionController::Base
 end
 
 RSpec.describe EventLoggerRails::LoggableController, type: :request do
-  let(:params) { { foo: 'bar' } }
+  let(:params) { { 'foo' => 'bar' } }
   let(:data_from_request) do
     {
       action: controller.action_name,
       controller: controller.controller_name.camelcase,
       method: request.method,
-      parameters: params.to_json,
+      parameters: request.params,
       path: request.path,
       remote_ip: request.remote_ip
     }

--- a/spec/lib/event_logger_rails/event_logger_spec.rb
+++ b/spec/lib/event_logger_rails/event_logger_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe EventLoggerRails::EventLogger do
     end
     # rubocop:enable RSpec/ExampleLength
 
+    context 'when sensitive data is provided' do
+      let(:data) { { password: 'foobar' } }
+      let(:filtered_data) { { password: '[FILTERED]' } }
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'logs the default severity, timestamp, event identifier, description, and data' do
+        method_call
+        log_output = JSON.parse(buffer.string, symbolize_names: true)
+        expect(log_output).to include(
+          environment: 'test',
+          event_description: event.description,
+          event_identifier: event.identifier,
+          host: anything,
+          level: 'WARN',
+          service_name: 'Dummy',
+          timestamp: match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?([+-]\d{2}:\d{2}|Z)?\z/),
+          **filtered_data
+        )
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+
     context 'when an identifier is provided instead of an EventLoggerRails::Event object' do
       let(:event) { 'event_logger_rails.event.testing' }
 


### PR DESCRIPTION
## Description

This PR adds sensitive param filtering and unifies request param logging.

- Add sensitive field filter
- Send unified params in hash format

## Testing

Follow these steps to test this PR:

* Point consuming app to this branch.
* Attempt to log an event with a sensitive param field, like user password.
* Verify log has filtered the value.
