### PR TITLE
Add support for replacing Rails logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0]
+## [0.3.1] - 2023-10-14
+
+### Added
+
+- Added support for using `EventLoggerRails::JsonLogger` as a Rails logger replacement.
+
+## [0.3.0] - 2023-10-05
 
 ### Added
 
@@ -64,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/d3d1rty/event_logger_rails/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/d3d1rty/event_logger_rails/compare/0.3.1...HEAD
+[0.3.0]: https://github.com/d3d1rty/event_logger_rails/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/d3d1rty/event_logger_rails/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/d3d1rty/event_logger_rails/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/d3d1rty/event_logger_rails/compare/0.1.0...0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    event_logger_rails (0.3.0)
+    event_logger_rails (0.3.1)
       rails (>= 7.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -344,6 +344,17 @@ Rails.application.configure do |config|
 end
 ```
 
+You can also configure the Rails logger to use `EventLoggerRails::JsonLogger` to render structured logs in JSON format with the additional app and request data.
+
+```ruby
+Rails.application.configure do
+  config.colorize_logging = false
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', :info)
+  logger = EventLoggerRails::JsonLogger.new($stdout)
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+end
+```
+
 ## Contributing
 
 Your inputs echo in this realm. Venture forth and materialize your thoughts through a PR.

--- a/lib/event_logger_rails/json_logger.rb
+++ b/lib/event_logger_rails/json_logger.rb
@@ -4,6 +4,8 @@ module EventLoggerRails
   ##
   # Writes log entries in JSON format
   class JsonLogger < ::Logger
+    include ActiveSupport::LoggerSilence
+
     def initialize(...)
       super(...)
       @formatter = proc do |level, timestamp, _progname, message|

--- a/lib/event_logger_rails/version.rb
+++ b/lib/event_logger_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EventLoggerRails
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
## Description

This PR adds support for replacing the Rails logger.

- Add support for silencer
- Add documentation
- Update version

## Testing

Follow these steps to test this PR:

* Point test app at this branch.
* Change logger to use `EventLoggerRails::JsonLogger`.
* Verify output is as expected.
